### PR TITLE
Pull in s/w serial support

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -24,6 +24,10 @@
 #define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 
+#ifdef USE_GDOLIB_SWSERIAL
+#include "gdoSoftwareSerial.h"
+#endif
+
 /***************************** LOCAL FUNCTION DECLARATIONS ****************************/
 static void obst_isr_handler(void *arg);
 static void gdo_main_task(void *arg);
@@ -113,6 +117,10 @@ static void *g_user_cb_arg;
 static uint32_t g_tx_delay_ms = 50;
 static uint32_t g_ttc_delay_s = 0;
 static portMUX_TYPE gdo_spinlock = portMUX_INITIALIZER_UNLOCKED;
+#ifdef USE_GDOLIB_SWSERIAL
+static MessageBufferHandle_t serial_tx_buffer;
+static TaskHandle_t serial_task_handle;
+#endif
 
 /******************************* PUBLIC API FUNCTIONS **********************************/
 
@@ -225,6 +233,7 @@ esp_err_t gdo_init(const gdo_config_t *config)
     }
   }
 
+#ifndef USE_GDOLIB_SWSERIAL
   // Begin in secplus protocol v1 as its the easiest to detect.
   uart_config_t uart_config = {
       .baud_rate = 1200,
@@ -260,6 +269,7 @@ esp_err_t gdo_init(const gdo_config_t *config)
   {
     return err;
   }
+#endif
 
   gdo_tx_queue = xQueueCreate(16, sizeof(gdo_tx_message_t));
   if (!gdo_tx_queue)
@@ -368,7 +378,11 @@ esp_err_t gdo_deinit(void)
     goto done;
   }
 
+#ifdef USE_GDOLIB_SWSERIAL
+  err = serial_stop();
+#else
   err = uart_driver_delete(g_config.uart_num);
+#endif
 
 done:
   return err;
@@ -390,6 +404,19 @@ esp_err_t gdo_start(gdo_event_callback_t event_callback, void *user_arg)
   }
   g_user_cb_arg = user_arg;
 
+#ifdef USE_GDOLIB_SWSERIAL
+  gdo_event_queue = xQueueCreate(16, sizeof(gdo_event_t));
+  if (!gdo_event_queue)
+  {
+    return ESP_ERR_NO_MEM;
+  }
+  esp_err_t err = serial_start(gdo_event_queue, &serial_tx_buffer, &serial_task_handle, g_config.uart_rx_pin, g_config.uart_tx_pin);
+  if (err != ESP_OK)
+  {
+    return err;
+  }
+  serial_set_protocol(g_status.protocol);
+#else
   esp_err_t err = uart_driver_install(g_config.uart_num, RX_BUFFER_SIZE, 0, 32,
                                       &gdo_event_queue, 0);
   if (err != ESP_OK)
@@ -398,6 +425,7 @@ esp_err_t gdo_start(gdo_event_callback_t event_callback, void *user_arg)
   }
 
   uart_flush(g_config.uart_num);
+#endif
 
   // Medium high priority as it needs to handle in real time, pin to CPU 1 so does not share with HomeKit/WiFi/mdns/etc.
 #ifdef CONFIG_FREERTOS_UNICORE
@@ -990,9 +1018,13 @@ static void gdo_sync_task(void *arg)
 
   if (g_status.protocol != GDO_PROTOCOL_SEC_PLUS_V2)
   {
+#ifdef USE_GDOLIB_SWSERIAL
+    serial_set_protocol(GDO_PROTOCOL_SEC_PLUS_V1);
+#else
     uart_set_baudrate(g_config.uart_num, 1200);
     uart_set_parity(g_config.uart_num, UART_PARITY_EVEN);
     uart_flush(g_config.uart_num);
+#endif
     xQueueReset(gdo_event_queue);
 
     // Delay forever if there is a smart panel connected to allow it to come online and sync before we do anything.
@@ -1015,7 +1047,9 @@ static void gdo_sync_task(void *arg)
       }
       else
       {
+#ifndef USE_GDOLIB_SWSERIAL
         uart_flush(g_config.uart_num);
+#endif
         xQueueReset(gdo_event_queue);
         esp_timer_start_periodic(v1_status_timer, 250 * 1000);
       }
@@ -1044,9 +1078,13 @@ static void gdo_sync_task(void *arg)
   uint32_t timeout = esp_timer_get_time() / 1000 + 5000;
   uint8_t sync_stage = 0;
   g_status.protocol = GDO_PROTOCOL_SEC_PLUS_V2;
+#ifdef USE_GDOLIB_SWSERIAL
+  serial_set_protocol(g_status.protocol);
+#else
   uart_set_baudrate(g_config.uart_num, 9600);
   uart_set_parity(g_config.uart_num, UART_PARITY_DISABLE);
   uart_flush(g_config.uart_num);
+#endif
   xQueueReset(gdo_event_queue);
 
   // We send a get openings because if we have a new client ID then the
@@ -1491,6 +1529,7 @@ static esp_err_t queue_command(gdo_command_t command, uint8_t nibble,
   print_buffer(g_status.protocol, message.packet, true);
   if (xQueueSendToBack(gdo_tx_queue, &message, 0) == pdFALSE)
   {
+    ESP_LOGE(TAG, "gdo TX queue full!");
     return ESP_ERR_NO_MEM;
   }
 
@@ -1498,10 +1537,33 @@ static esp_err_t queue_command(gdo_command_t command, uint8_t nibble,
 }
 
 /**
- * @brief Transmits a packet to the GDO from the UART.
+ * @brief Transmits a packet to the GDO from the UART or s/w serial.
  * @param packet The packet to send to the GDO.
- * @return ESP_OK on success, other non-zero errors from the UART driver.
+ * @return ESP_OK on success, other non-zero errors from the UART or s/w serial driver.
  */
+#ifdef USE_GDOLIB_SWSERIAL
+static esp_err_t transmit_packet(uint8_t *packet)
+{
+  uint32_t rc;
+  serial_transmit_t tx_packet;
+
+  tx_packet.sendingTask = xTaskGetCurrentTaskHandle();
+  tx_packet.size = (g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2) ? 19 : 1;
+  memcpy(tx_packet.packet, packet, tx_packet.size);
+
+  // Queue up the packet for the software serial task to pick off and process
+  if (!xMessageBufferSend(serial_tx_buffer, &tx_packet, sizeof(tx_packet), portMAX_DELAY))
+  {
+    ESP_LOGE(TAG, "s/w serial TX buffer full!");
+    return ESP_ERR_NO_MEM;
+  }
+  // Notify the s/w serial task that packet is waiting to be sent
+  xTaskNotify(serial_task_handle, 0, eSetValueWithOverwrite);
+  // Wait for the s/w serial task to notify that packet is sent.
+  xTaskNotifyWait(0, 0, &rc, portMAX_DELAY);
+  return (esp_err_t)rc;
+}
+#else
 static esp_err_t transmit_packet(uint8_t *packet)
 {
   esp_err_t err = ESP_OK;
@@ -1566,6 +1628,7 @@ static esp_err_t transmit_packet(uint8_t *packet)
 
   return err;
 }
+#endif
 
 /**
  * @brief Decodes a packet received from the GDO and updates the status.
@@ -1576,7 +1639,8 @@ static void decode_v1_packet(uint8_t *packet)
   gdo_v1_command_t cmd = (gdo_v1_command_t)packet[0];
   uint8_t resp = packet[1];
 
-  if (cmd == V1_CMD_QUERY_DOOR_STATUS)
+  // If not synced then check that we are not receiving echo back of our sequence of sync status commands
+  if (cmd == V1_CMD_QUERY_DOOR_STATUS && (!g_status.synced && resp != V1_CMD_QUERY_OTHER_STATUS))
   {
     gdo_door_state_t door_state = GDO_DOOR_STATE_UNKNOWN;
     uint8_t val = resp & 0x7;
@@ -1607,12 +1671,12 @@ static void decode_v1_packet(uint8_t *packet)
   {
     queue_v1_command(V1_CMD_QUERY_OTHER_STATUS);
   }
-  else if (cmd == V1_CMD_QUERY_OTHER_STATUS)
+  else if (cmd == V1_CMD_QUERY_OTHER_STATUS && (!g_status.synced && resp != V1_CMD_QUERY_DOOR_STATUS && resp != V1_CMD_QUERY_OTHER_STATUS && resp != V1_CMD_OBSTRUCTION))
   {
     update_light_state((gdo_light_state_t)((resp >> 2) & 1));
     update_lock_state((gdo_lock_state_t)((~resp >> 3) & 1));
   }
-  else if (cmd == V1_CMD_OBSTRUCTION)
+  else if (cmd == V1_CMD_OBSTRUCTION && (!g_status.synced && resp != V1_CMD_QUERY_DOOR_STATUS))
   {
     update_obstruction_state(resp == 0 ? GDO_OBSTRUCTION_STATE_CLEAR : GDO_OBSTRUCTION_STATE_OBSTRUCTED);
   }
@@ -1654,7 +1718,7 @@ static void decode_packet(uint8_t *packet)
   }
   else
   {
-    ESP_LOGI(TAG,
+    ESP_LOGD(TAG,
              "received rolling=%07" PRIx32 " fixed=%010" PRIx64
              " data=%08" PRIx32,
              rolling, fixed, data);
@@ -1733,9 +1797,11 @@ static void decode_packet(uint8_t *packet)
  */
 static void gdo_main_task(void *arg)
 {
+#ifndef USE_GDOLIB_SWSERIAL
   uint8_t rx_buffer[RX_BUFFER_SIZE * 2]; // double the size to prevent overflow
   uint16_t rx_buf_index = 0;
   uint8_t rx_pending = 0;
+#endif
   gdo_tx_message_t tx_message = {};
   gdo_event_t event = {};
   gdo_cb_event_t cb_event = GDO_CB_EVENT_MAX;
@@ -1751,6 +1817,39 @@ static void gdo_main_task(void *arg)
 
       switch ((int)event.gdo_event)
       {
+#ifdef USE_GDOLIB_SWSERIAL
+      case SERIAL_EVENT_DATA:
+      {
+        if (!g_status.protocol)
+        {
+          uint16_t rx_packet_size = event.serial_event.size;
+          if (rx_packet_size == 2)
+          {
+            ESP_LOGD(TAG, "Received %u bytes, using protocol V1", rx_packet_size);
+            g_status.protocol = GDO_PROTOCOL_SEC_PLUS_V1;
+          }
+          else if (rx_packet_size == 19)
+          {
+            ESP_LOGD(TAG, "Received %u bytes, using protocol V2", rx_packet_size);
+            g_status.protocol = GDO_PROTOCOL_SEC_PLUS_V2;
+          }
+          else
+          {
+            ESP_LOGD(TAG, "Received %u bytes, unknown protocol", rx_packet_size);
+          }
+        }
+        print_buffer(g_status.protocol, event.serial_event.packet, false);
+        if (g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2)
+        {
+          decode_packet(event.serial_event.packet);
+        }
+        else
+        {
+          decode_v1_packet(event.serial_event.packet);
+        }
+        break;
+      }
+#else
       case UART_BREAK:
         // All messages from the GDO start with a break if using V2 protocol.
         if (g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2)
@@ -1917,6 +2016,7 @@ static void gdo_main_task(void *arg)
         rx_buf_index = 0;
         xQueueReset(gdo_event_queue);
         break;
+#endif
       case GDO_EVENT_TX_PENDING:
       {
         uint32_t now = esp_timer_get_time() / 1000;
@@ -1931,11 +2031,16 @@ static void gdo_main_task(void *arg)
           break;
         }
 
+#ifdef USE_GDOLIB_SWSERIAL
+        if (gpio_get_level(g_config.uart_rx_pin))
+#else
         if (rx_pending || gpio_get_level(g_config.uart_rx_pin))
+#endif
         {
           // If not synced yet just delete the message as the sync loop will resend it
           if (!g_status.synced)
           {
+            ESP_LOGD(TAG, "Collision detected, ignoring as in middle of sync");
             xQueueReceive(gdo_tx_queue, &tx_message, 0);
             free(tx_message.packet);
             break;

--- a/gdoSoftwareSerial.cpp
+++ b/gdoSoftwareSerial.cpp
@@ -1,0 +1,334 @@
+/****************************************************************************
+ * Wrapper for GDOLIB to use EspSoftwareSerial
+ *
+ * Copyright (c) 2023-25 David A Kerr... https://github.com/dkerr64/
+ * All Rights Reserved.
+ * Licensed under terms of the GPL-3.0 License.
+ */
+#ifdef USE_GDOLIB_SWSERIAL
+// skip entire file if not compiling with s/w serial
+#include "gdo_priv.h"
+#include "SoftwareSerial.h"
+#include "gdoSoftwareSerial.h"
+
+static const uint8_t SECPLUS2_CODE_LEN = 19;
+static const uint32_t SECPLUS2_PREAMBLE = 0x00550100;
+
+struct TaskParams
+{
+    gpio_num_t rxPin;
+    gpio_num_t txPin;
+    MessageBufferHandle_t txBuffer;
+    QueueHandle_t rxQueue;
+};
+typedef struct TaskParams TaskParams_t;
+
+enum SecPlus2ReaderMode : uint8_t
+{
+    SCANNING,
+    RECEIVING,
+};
+
+class SecPlus2Reader
+{
+private:
+    bool m_is_reading = false;
+    uint32_t m_msg_start = 0;
+    size_t m_byte_count = 0;
+    uint8_t m_rx_buf[SECPLUS2_CODE_LEN] = {0x55, 0x01, 0x00};
+    SecPlus2ReaderMode m_mode = SCANNING;
+    const char *TAG = "ratgdo-reader";
+
+public:
+    SecPlus2Reader() = default;
+
+    bool push_byte(uint8_t inp)
+    {
+        bool msg_ready = false;
+
+        switch (m_mode)
+        {
+        case SCANNING:
+            m_msg_start <<= 8;
+            m_msg_start |= inp;
+            m_msg_start &= 0x00FFFFFF;
+
+            if (m_msg_start == SECPLUS2_PREAMBLE)
+            {
+                m_byte_count = 3;
+                m_mode = RECEIVING;
+            }
+            break;
+
+        case RECEIVING:
+            m_rx_buf[m_byte_count] = inp;
+            m_byte_count += 1;
+
+            if (m_byte_count == SECPLUS2_CODE_LEN)
+            {
+                m_mode = SCANNING;
+                m_msg_start = 0;
+                msg_ready = true;
+            }
+            break;
+        }
+        return msg_ready;
+    };
+
+    uint8_t *fetch_buf(void)
+    {
+        return m_rx_buf;
+    }
+};
+
+TaskHandle_t serial_task_handle;
+TaskParams_t serial_task_params;
+SoftwareSerial swSerial;
+SecPlus2Reader reader;
+gdo_protocol_type_t serial_protocol = GDO_PROTOCOL_UNKNOWN;
+
+/***************************** LOCAL FUNCTION DECLARATIONS ****************************/
+void serial_task(TaskParams_t *arg);
+
+esp_err_t serial_start(QueueHandle_t rxQueue, MessageBufferHandle_t *txBuffer, TaskHandle_t *serialTask, gpio_num_t rxPin, gpio_num_t txPin)
+{
+    // rxQueue is passed into us, that is where we will send received packets
+    // txBuffer we will create and return, that is where packets to transmit will be sent to us
+
+    if (!txBuffer || !serialTask)
+        return ESP_ERR_INVALID_ARG;
+
+    *txBuffer = xMessageBufferCreate(sizeof(serial_transmit_t) + 8);
+
+    if (!*txBuffer)
+        return ESP_ERR_NO_MEM;
+
+    serial_task_params.txBuffer = *txBuffer;
+    serial_task_params.rxQueue = rxQueue;
+    serial_task_params.rxPin = rxPin;
+    serial_task_params.txPin = txPin;
+
+    // Assume Sec+1.0 protocol to start
+    swSerial.begin(1200, SWSERIAL_8E1, rxPin, txPin, true);
+    serial_set_protocol(serial_protocol);
+
+    // Create task to loop on checking for serial port data.
+    // High priority as it needs to handle in real time, pin to CPU 1 so does not share with HomeKit/WiFi/mdns/etc.
+#ifdef CONFIG_FREERTOS_UNICORE
+    if (xTaskCreate((TaskFunction_t)serial_task, "serial_task", 4096, &serial_task_params, 15, &serial_task_handle) != pdPASS)
+#else
+    if (xTaskCreatePinnedToCore((TaskFunction_t)serial_task, "serial_task", 4096, &serial_task_params, 15, &serial_task_handle, 1) != pdPASS)
+#endif
+    {
+        serial_stop();
+        return ESP_ERR_NO_MEM;
+    }
+    *serialTask = serial_task_handle;
+
+    // Use modified EspSoftwareSerial that will notify us if a byte is available
+    // to read. This avoids need to have task spin in a tight loop polling for data.
+    swSerial.enableNotify(serial_task_handle);
+    return ESP_OK;
+}
+
+esp_err_t serial_stop()
+{
+    if (!swSerial)
+        return ESP_FAIL;
+    swSerial.end();
+    if (serial_task_handle)
+    {
+        vTaskDelete(serial_task_handle);
+        serial_task_handle = NULL;
+    }
+    if (serial_task_params.txBuffer)
+    {
+        vMessageBufferDelete(serial_task_params.txBuffer);
+        serial_task_params.txBuffer = NULL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t serial_set_protocol(gdo_protocol_type_t protocol)
+{
+    serial_protocol = protocol;
+    ESP_LOGI(TAG, "Set serial port protocol to %s", gdo_protocol_type_to_string(protocol));
+    if (protocol == GDO_PROTOCOL_SEC_PLUS_V2)
+    {
+        swSerial.begin(9600, SWSERIAL_8N1);
+        swSerial.enableIntTx(false);
+        swSerial.enableAutoBaud(true); // found in ratgdo/espsoftwareserial branch autobaud
+    }
+    else
+    {
+        swSerial.begin(1200, SWSERIAL_8E1);
+        swSerial.enableAutoBaud(false);
+    }
+    swSerial.flush();
+    return ESP_OK;
+}
+
+void serial_task(TaskParams *arg)
+{
+    int64_t last_rx;
+    static const uint8_t RX_LENGTH = 2; // for Sec+1.0
+    uint8_t rxPacket[RX_LENGTH];        // for Sec+1.0
+    uint16_t byteCount = 0;             // for Sec+1.0
+    bool readingMsg = false;            // for Sec+1.0
+    serial_event_t serial_event;        // for received packets
+    serial_transmit_t txPacket;         // for outbound packets
+
+    ESP_LOGI(TAG, "Starting GDO software serial task.");
+    for (;;)
+    {
+        while (swSerial.available())
+        {
+            // data is available on the serial port, read it.
+            uint8_t serialByte = swSerial.read();
+            last_rx = esp_timer_get_time();
+            if (serial_protocol == GDO_PROTOCOL_SEC_PLUS_V2)
+            {
+                //--------------- Sec+2.0 ----------------
+                if (reader.push_byte(serialByte))
+                {
+                    // Full packet received, send it to rxQueue
+                    serial_event.event = SERIAL_EVENT_DATA;
+                    serial_event.size = SECPLUS2_CODE_LEN;
+                    memcpy(serial_event.packet, reader.fetch_buf(), SECPLUS2_CODE_LEN);
+                    if (xQueueSendToBack(arg->rxQueue, &serial_event, 0) == pdFALSE)
+                    {
+                        // Queue is full, cannot send, log error and ignore.
+                        ESP_LOGE(TAG, "Unable to queue RX packet");
+                    }
+                }
+            }
+            else
+            {
+                //--------------- Sec+1.0 ----------------
+                if (swSerial.readParity() != swSerial.parityEven(serialByte))
+                {
+                    readingMsg = false;
+                    byteCount = 0;
+                    ESP_LOGW(TAG, "Parity error 0x%02X", serialByte);
+                    continue;
+                }
+
+                bool gotMessage = false;
+                if (!readingMsg)
+                {
+                    // valid?
+                    if (serialByte >= 0x30 && serialByte <= 0x3A)
+                    {
+                        rxPacket[0] = serialByte;
+                        byteCount = 1;
+                        readingMsg = true;
+                    }
+                    // is it single byte command?
+                    if (serialByte >= 0x30 && serialByte <= 0x37)
+                    {
+                        rxPacket[1] = 0;
+                        readingMsg = false;
+                        gotMessage = true;
+                    }
+                }
+                else
+                {
+                    // save next byte
+                    rxPacket[byteCount++] = serialByte;
+                    if (byteCount == RX_LENGTH)
+                    {
+                        readingMsg = false;
+                        gotMessage = true;
+                    }
+
+                    if (gotMessage == false && (esp_timer_get_time() - last_rx) > (100 * 1000))
+                    {
+                        ESP_LOGW(TAG, "RX message timeout");
+                        // if we have a partial packet and it's been over 100ms since last byte was read,
+                        // the rest is not coming (a full packet should be received in ~20ms),
+                        // discard it so we can read the following packet correctly
+                        readingMsg = false;
+                        byteCount = 0;
+                    }
+                }
+
+                if (gotMessage)
+                {
+                    serial_event.event = SERIAL_EVENT_DATA;
+                    serial_event.size = byteCount;
+                    serial_event.packet[0] = rxPacket[0];
+                    serial_event.packet[1] = rxPacket[1];
+                    if (xQueueSendToBack(arg->rxQueue, &serial_event, 0) == pdFALSE)
+                    {
+                        // Queue is full, cannot send, log error and ignore.
+                        ESP_LOGE(TAG, "Unable to queue RX packet");
+                    }
+                    byteCount = 0;
+                }
+            }
+        }
+
+        // We have read all data from serial port.  Now look and see if there is a packet to send.
+        if (xMessageBufferReceive(arg->txBuffer, &txPacket, sizeof(txPacket), 0))
+        {
+            esp_err_t err = ESP_OK;
+            // If size > 1 then it must be Sec+2.0.
+            if (txPacket.size > 1)
+            {
+                //--------------- Sec+2.0 ----------------
+                gpio_set_level(arg->txPin, 1);
+                ets_delay_us(1300);
+                gpio_set_level(arg->txPin, 0);
+                ets_delay_us(130);
+
+                // check to see if anyone else is continuing to assert the bus after we have released it
+                if (gpio_get_level(arg->rxPin))
+                {
+                    err = ESP_FAIL;
+                    ESP_LOGE(TAG, "Collision detected trying to send packet");
+                    // There is a test for this in the sending gdolib code and it requeues, so this may never occur.
+                }
+                else
+                {
+                    swSerial.enableRx(false); // Disable RX so our own packet is not immediately read back.
+                    swSerial.write(txPacket.packet, txPacket.size);
+                    ets_delay_us(100); // Why is this needed?
+                    swSerial.enableRx(true);
+                }
+            }
+            else
+            {
+                //--------------- Sec+1.0 ----------------
+                if (gpio_get_level(arg->rxPin))
+                {
+                    err = ESP_FAIL;
+                    ESP_LOGE(TAG, "Collision detected trying to send packet");
+                    // There is a test for this in the sending gdolib code and it requeues, so this may never occur.
+                }
+                else
+                {
+                    swSerial.write(*txPacket.packet);
+                }
+            }
+            // Notify sending task that packet has been sent
+            xTaskNotify(txPacket.sendingTask, err, eSetValueWithOverwrite);
+        }
+
+        if (!swSerial.available())
+        {
+            // Wait until we are notified of either a packet to send (by gdolib)
+            // or that a byte is available to read (by SoftwareSerial)
+            // vTaskDelay(pdMS_TO_TICKS(2));
+            if (xTaskNotifyWait(0, 0, NULL, pdMS_TO_TICKS(1000)) == pdFALSE)
+            {
+                if (serial_protocol == GDO_PROTOCOL_SEC_PLUS_V2)
+                    // Sec+2.0 does not have heartbeat on serial, so it always times out.
+                    ESP_LOGV(TAG, "Timeout in xTaskNotifyWait");
+                else
+                    // Sec+1.0 timeout is likely to indicate a problem
+                    ESP_LOGW(TAG, "Timeout in xTaskNotifyWait");
+            }
+        }
+    }
+}
+#endif

--- a/gdoSoftwareSerial.h
+++ b/gdoSoftwareSerial.h
@@ -1,0 +1,25 @@
+/****************************************************************************
+ * Wrapper for GDOLIB to use EspSoftwareSerial
+ *
+ * Copyright (c) 2023-25 David A Kerr... https://github.com/dkerr64/
+ * All Rights Reserved.
+ * Licensed under terms of the GPL-3.0 License.
+ */
+
+#ifndef _GDOSOFTWARESERIAL_H
+#define _GDOSOFTWARESERIAL_H
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    extern esp_err_t serial_start(QueueHandle_t rxQueue, MessageBufferHandle_t *txBuffer, TaskHandle_t *serialtask, gpio_num_t rxPin, gpio_num_t txPin);
+    extern esp_err_t serial_stop();
+    extern esp_err_t serial_set_protocol(gdo_protocol_type_t protocol);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+#endif // _GDOSOFTWARESERIAL_H

--- a/gdo_priv.h
+++ b/gdo_priv.h
@@ -165,10 +165,35 @@ extern "C"
         esp_timer_handle_t timer;
     } gdo_sched_evt_args_t;
 
+#ifdef USE_GDOLIB_SWSERIAL
+    typedef enum
+    {
+        SERIAL_EVENT_DATA = GDO_EVENT_MAX + 1,
+        SERIAL_EVENT_MAX,
+    } serial_event_type_t;
+
+    typedef struct
+    {
+        serial_event_type_t event;
+        size_t size;
+        uint8_t packet[20];
+    } serial_event_t;
+
+    typedef struct
+    {
+        TaskHandle_t sendingTask;
+        size_t size;
+        uint8_t packet[20];
+    } serial_transmit_t;
+#endif
+
     typedef union
     {
         gdo_event_type_t gdo_event;
         uart_event_t uart_event;
+#ifdef USE_GDOLIB_SWSERIAL
+        serial_event_t serial_event;
+#endif
     } gdo_event_t;
 
     const char *cmd_to_string(gdo_command_t cmd);


### PR DESCRIPTION
To compile with s/w serial add `-D USE_GDOLIB_SWSERIAL` to compiler command line.

s/w serial is dependent on https://github.com/dkerr64/espsoftwareserial.git which you must pull into your source tree.  In platformio.ini this can be done in the `lib_deps=` section.