### PR TITLE
Updates for main branch

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -24,6 +24,8 @@
 #define __STDC_FORMAT_MACROS 1
 #include <inttypes.h>
 
+static const char *TAG = "gdolib";
+
 /***************************** LOCAL FUNCTION DECLARATIONS ****************************/
 static void obst_isr_handler(void *arg);
 static void gdo_main_task(void *arg);

--- a/gdo_priv.h
+++ b/gdo_priv.h
@@ -32,8 +32,6 @@ extern "C"
 #define GDO_PACKET_SIZE ((g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2) ? 19UL : 2UL)
 #define GDO_DRY_CONTACT_DEBOUNCE_MS 50
 
-    static const char *TAG = "gdolib";
-
     typedef enum
     {
         GDO_CMD_UNKNOWN = 0x000,

--- a/gdo_utils.c
+++ b/gdo_utils.c
@@ -216,11 +216,11 @@ void print_buffer(gdo_protocol_type_t protocol, uint8_t *buf, bool is_tx)
 {
     if (protocol == GDO_PROTOCOL_DRY_CONTACT)
     {
-        ESP_LOGD(TAG, "Dry Contact set pin %2d to %1d", buf[0], buf[1]);
+        ESP_LOGV(TAG, "Dry Contact set pin %2d to %1d", buf[0], buf[1]);
     }
     else if (protocol == GDO_PROTOCOL_SEC_PLUS_V2)
     {
-        ESP_LOGD(TAG, "%s: "
+        ESP_LOGV(TAG, "%s: "
                       "[%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]",
                  is_tx ? "TX" : "RX",
                  buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9],
@@ -228,11 +228,11 @@ void print_buffer(gdo_protocol_type_t protocol, uint8_t *buf, bool is_tx)
     }
     else if (is_tx)
     {
-        ESP_LOGD(TAG, "TX [%02X]", buf[0]);
+        ESP_LOGV(TAG, "TX [%02X]", buf[0]);
     }
     else
     {
-        ESP_LOGD(TAG, "RX [%02X %02X]", buf[0], buf[1]);
+        ESP_LOGV(TAG, "RX [%02X %02X]", buf[0], buf[1]);
     }
 }
 

--- a/gdo_utils.c
+++ b/gdo_utils.c
@@ -19,6 +19,8 @@
 #include "gdo.h"
 #include "gdo_priv.h"
 
+static const char *TAG = "gdo_utils";
+
 const char *gdo_door_state_str[] = {
     "Unknown",
     "Open",

--- a/include/gdo.h
+++ b/include/gdo.h
@@ -274,15 +274,19 @@ extern "C"
 
     /**
      * @brief Turns the light on.
+     * @param check if true then query the door status after setting light on.
      * @return ESP_OK on success, ESP_ERR_NO_MEM if the queue is full, ESP_FAIL if the encoding fails.
      */
-    esp_err_t gdo_light_on(void);
+    esp_err_t gdo_light_on();
+    esp_err_t gdo_light_on_check(bool check);
 
     /**
      * @brief Turns the light off.
+     * @param check if true then query the door status after setting light off.
      * @return ESP_OK on success, ESP_ERR_NO_MEM if the queue is full, ESP_FAIL if the encoding fails.
      */
-    esp_err_t gdo_light_off(void);
+    esp_err_t gdo_light_off();
+    esp_err_t gdo_light_off_check(bool check);
 
     /**
      * @brief Toggles the light.


### PR DESCRIPTION
Updates...

- Delete the V1 panel emulation timer when we de-initialize the GDOLIB.  Currently the timer continues to run which is bad because it tries to send data... and the ability to do that is getting shutdown in the `gdo_deinit()` function.
- The const string `TAG` for debug messages is set in a header file.  This means that I cannot set a unique tag to identify the actual source file that a message is logged from.  I moved it from header file into each c / cpp file.
- When turning the GDO light on or off, the library immediately asks the GDO for status.  This queues up multiple packets to be sent and received.  This takes considerable time... more than the 500ms that I am attempting to flash the lights at during a TTC delay, and that causes the transmit queue to get backed up.  This change adds an option to skip that status request, so flashing can proceed at intended rate without generating lots of data on the wire.  This mainly impacts Sec+2.0, but it also disables checking current status for 1.0 as well... so the toggle is always sent whether the library thinks the light is on or off.
- And I moved some debug level logs to verbose level.  This is because turning on debug on Sec+1.0 then floods the log with all the TX/RX from the V1 panel emulation timer, making it difficult to catch the debug log you really care about.
