### PR TITLE
Fix obstruction sensor logic as it was not correctly detecting state.

### DIFF
--- a/gdo_priv.h
+++ b/gdo_priv.h
@@ -160,7 +160,8 @@ extern "C"
     typedef struct
     {
         int64_t sleep_micros;
-        uint8_t count;
+        uint32_t count;
+        portMUX_TYPE mux;
     } gdo_obstruction_stats_t;
 
     typedef struct


### PR DESCRIPTION
Obstruction sensing was not working for me... would change to obstructed then never change back to clear.  I changed
the logic to match that in ESP home firmware.  I also wrapped the ISR and timer code that touches the same variable in mutex.  This may not be strictly necessary as all the ISR does is increment one variable, but best to be safe... as there is a test and a reset in the timer code so we _could_ miss an increment if not protected.

I changed count from 8-bit to 32-bit because (I think) 32-bit architectures are more efficient accessing data on 32-bit boundaries/chunks.