### PR TITLE
OBST Override

### DIFF
--- a/gdo.c
+++ b/gdo.c
@@ -1655,7 +1655,7 @@ static esp_err_t gdo_dc_toggle_pin(gpio_num_t pin)
         .door_cmd = false,
         .nibble = 0,
     };
-    return schedule_command(&args, 500 * 1000);
+    return schedule_command(&args, GDO_DRY_CONTACT_PULSE_WIDTH_MS * 1000);
   }
   return err;
 }
@@ -3061,7 +3061,7 @@ static void gdo_contact_task(void *arg)
       .mode = GPIO_MODE_INPUT,
       .pull_up_en = GPIO_PULLUP_ENABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
-      .intr_type = GPIO_INTR_ANYEDGE,
+      .intr_type = GPIO_INTR_NEGEDGE,
   };
 
   err = gpio_config(&io_conf);

--- a/gdo_priv.h
+++ b/gdo_priv.h
@@ -31,6 +31,7 @@ extern "C"
 #define RX_BUFFER_SIZE 160
 #define GDO_PACKET_SIZE ((g_status.protocol == GDO_PROTOCOL_SEC_PLUS_V2) ? 19UL : 2UL)
 #define GDO_DRY_CONTACT_DEBOUNCE_MS 50
+#define GDO_DRY_CONTACT_PULSE_WIDTH_MS 200
 
     typedef enum
     {
@@ -140,6 +141,7 @@ extern "C"
         GDO_CONTACT_UNKNOWN = 0,
         GDO_CONTACT_DOOR_OPEN,
         GDO_CONTACT_DOOR_CLOSE,
+        GDO_CONTACT_DOOR_TOGGLE,
         GDO_CONTACT_MAX,
     } gdo_contact_type_t;
 

--- a/gdo_utils.c
+++ b/gdo_utils.c
@@ -120,6 +120,7 @@ const char *gdo_protocol_type_str[] = {
     "Security+ 1.0",
     "Security+ 2.0",
     "Security+ 1.0 with smart panel",
+    "Dry Contact",
 };
 
 const char *cmd_to_string(gdo_command_t cmd)
@@ -216,7 +217,7 @@ void print_buffer(gdo_protocol_type_t protocol, uint8_t *buf, bool is_tx)
 {
     if (protocol == GDO_PROTOCOL_DRY_CONTACT)
     {
-        ESP_LOGV(TAG, "Dry Contact set pin %2d to %1d", buf[0], buf[1]);
+        ESP_LOGD(TAG, "Dry Contact set pin %2d to %1d", buf[0], buf[1]);
     }
     else if (protocol == GDO_PROTOCOL_SEC_PLUS_V2)
     {

--- a/include/gdo.h
+++ b/include/gdo.h
@@ -164,6 +164,7 @@ extern "C"
         bool synced;                          // Synced state
         bool ttc_enabled;                     // ttc active
         bool toggle_only;                     // Used when the door opener only supports the toggle command.
+        bool obst_override;                   // Used when the door opener has no obstruction sensors.
         bool tof_timer_active;                // ToF interval timer active
         bool obst_test_pulse_timer_active;    // Obstruction test pulse output pin timer active
         uint16_t openings;                    // Number of openings
@@ -468,6 +469,12 @@ extern "C"
      * @param toggle_only true to enable toggle only mode, false to disable.
      */
     void gdo_set_toggle_only(bool toggle_only);
+
+    /**
+     * @brief Enables or disables obstruction override, some openers that do not have obstruction sensors connected.
+     * @param obst_override true to enable override, false to disable.
+     */
+    void gdo_set_obst_override(bool obst_override);
 
     /************************************* VEHICLE Functions *****************************************/
 

--- a/include/gdo.h
+++ b/include/gdo.h
@@ -171,7 +171,7 @@ extern "C"
         uint16_t open_ms;                     // Time door takes to open from fully closed in milliseconds
         uint16_t close_ms;                    // Time door takes to close from fully open in milliseconds
         uint16_t vehicle_parked_threshold;    // Distance thats considered a parked state
-        uint16_t vehicle_parked_threshold_variance; // The variance used to determine if the vehicle is parked 
+        uint16_t vehicle_parked_threshold_variance; // The variance used to determine if the vehicle is parked
         int32_t door_position;                // Door position in percentage (0-10000) [OPEN-CLOSED]
         int32_t door_target;                  // Door target position in percentage (0-10000) [OPEN-CLOSED]
         uint32_t client_id;                   // Client ID
@@ -193,6 +193,7 @@ extern "C"
         gpio_num_t rf_rx_pin;             // RF RX pin
         gpio_num_t dc_open_pin;           // dry contact open sensor input pin
         gpio_num_t dc_close_pin;          // dry contact close sensor input pin
+        gpio_num_t dc_toggle_pin;         // dry contact toggle input pin
         gpio_num_t dc_discrete_open_pin;  // dry contact open door output pin
         gpio_num_t dc_discrete_close_pin; // dry contact close door output pin
         uint32_t dc_debounce_ms;          // dry contact debounce timer duration in milliseconds.
@@ -483,7 +484,7 @@ extern "C"
      * @param interval the interval time in micro seconds
      * @param enabled the flag to enable or disable the timer on gdo_start
      * @return ESP_OK on success, ESP_ERR_INVALID_ARG if the interval is less than 1000
-     * @note Init config->obst_tp_pin with the desired GPIO pin 
+     * @note Init config->obst_tp_pin with the desired GPIO pin
     */
     esp_err_t gdo_set_obst_test_pulse_timer(uint32_t interval, bool enabled);
 
@@ -495,7 +496,7 @@ extern "C"
 
     /**
      * @brief Sets the vehicle parked threshold variance in cm
-     * @param vehicle_parked_threshold_variance within this variance the state will be stable 
+     * @param vehicle_parked_threshold_variance within this variance the state will be stable
      */
     esp_err_t gdo_set_vehicle_parked_threshold_variance(uint16_t vehicle_parked_threshold_variance);
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "GDOLIB",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "Library for Secplus GDO's",
   "keywords": "security+v1, security+v2, drycontact",
   "repository": {


### PR DESCRIPTION
Adds support for overriding the OBST input where no OBST sensors are required. 